### PR TITLE
Removed Django2.2 DeprecationWarning

### DIFF
--- a/tastypie_swagger/views.py
+++ b/tastypie_swagger/views.py
@@ -4,7 +4,7 @@ import json
 from django.views.generic import TemplateView
 from django.http import HttpResponse, Http404
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 import tastypie
 


### PR DESCRIPTION
The warning:
```
.../site-packages/tastypie_swagger/views.py:7: RemovedInDjango20Warning: Importing from django.core.urlresolvers is deprecated in favor of django.urls.
```
